### PR TITLE
Add a Remove Volumes task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ crashlytics-build.properties
 
 # Vagrant
 .vagrant/
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeDownForced` task stops the application and removes the containers.
 
+`composeDownRemoveVolumes` task stops/removes running containers and removes associated volumes. This is useful for doing a clean reset of the volume (possibly a database) without changing the gradle configuration.
+
 `composePull` task pulls and optionally builds the images required by the application. This is useful, for example, with a CI platform that caches docker images to decrease build times.
 
 `composeBuild` task builds the services of the application.
@@ -17,7 +19,6 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeLogs` task stores logs from all containers to files in `containerLogToDir` directory.
 
-`composeStopRemoveVolumes` task stops running containers and removes associated volumes. This is useful for doing a clean reset of the volume (possibly a database) without changing the gradle configuration.
 
 ## Quick start
 ```gradle

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeLogs` task stores logs from all containers to files in `containerLogToDir` directory.
 
+`composeStopRemoveVolumes` task stops running containers and removes associated volumes. This is useful for doing a clean reset of the volume (possibly a database) without changing the gradle configuration.
+
 ## Quick start
 ```gradle
 buildscript {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -6,6 +6,7 @@ import com.avast.gradle.dockercompose.tasks.ComposeDownForced
 import com.avast.gradle.dockercompose.tasks.ComposeLogs
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposePush
+import com.avast.gradle.dockercompose.tasks.ComposeStopRemoveVolumes
 import com.avast.gradle.dockercompose.tasks.ComposeUp
 import com.avast.gradle.dockercompose.tasks.ServiceInfoCache
 import org.gradle.api.Project
@@ -27,6 +28,7 @@ class ComposeSettings {
     final ComposePull pullTask
     final ComposeLogs logsTask
     final ComposePush pushTask
+	final ComposeStopRemoveVolumes stopRemoveVolumesTask
     final Project project
     final DockerExecutor dockerExecutor
     final ComposeExecutor composeExecutor
@@ -92,6 +94,8 @@ class ComposeSettings {
         logsTask.settings = this
         pushTask = project.tasks.create(name ? "${name}ComposePush" : 'composePush', ComposePush)
         pushTask.settings = this
+		stopRemoveVolumesTask = project.tasks.create(name ? "${name}ComposeStopRemoveVolumes" : 'composeStopRemoveVolumes', ComposeStopRemoveVolumes)
+		stopRemoveVolumesTask.settings = this
 
         this.dockerExecutor = new DockerExecutor(this)
         this.composeExecutor = new ComposeExecutor(this)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -6,7 +6,7 @@ import com.avast.gradle.dockercompose.tasks.ComposeDownForced
 import com.avast.gradle.dockercompose.tasks.ComposeLogs
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposePush
-import com.avast.gradle.dockercompose.tasks.ComposeStopRemoveVolumes
+import com.avast.gradle.dockercompose.tasks.ComposeDownRemoveVolumes
 import com.avast.gradle.dockercompose.tasks.ComposeUp
 import com.avast.gradle.dockercompose.tasks.ServiceInfoCache
 import org.gradle.api.Project
@@ -28,7 +28,7 @@ class ComposeSettings {
     final ComposePull pullTask
     final ComposeLogs logsTask
     final ComposePush pushTask
-	final ComposeStopRemoveVolumes stopRemoveVolumesTask
+	final ComposeDownRemoveVolumes downRemoveVolumesTask
     final Project project
     final DockerExecutor dockerExecutor
     final ComposeExecutor composeExecutor
@@ -94,8 +94,8 @@ class ComposeSettings {
         logsTask.settings = this
         pushTask = project.tasks.create(name ? "${name}ComposePush" : 'composePush', ComposePush)
         pushTask.settings = this
-		stopRemoveVolumesTask = project.tasks.create(name ? "${name}ComposeStopRemoveVolumes" : 'composeStopRemoveVolumes', ComposeStopRemoveVolumes)
-		stopRemoveVolumesTask.settings = this
+		downRemoveVolumesTask = project.tasks.create(name ? "${name}ComposeDownRemoveVolumes" : 'composeDownRemoveVolumes', ComposeDownRemoveVolumes)
+		downRemoveVolumesTask.settings = this
 
         this.dockerExecutor = new DockerExecutor(this)
         this.composeExecutor = new ComposeExecutor(this)

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownRemoveVolumes.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownRemoveVolumes.groovy
@@ -5,17 +5,17 @@ import org.gradle.api.tasks.TaskAction
 
 import com.avast.gradle.dockercompose.ComposeSettings
 
-public class ComposeStopRemoveVolumes extends DefaultTask {
+public class ComposeDownRemoveVolumes extends DefaultTask {
 	ComposeSettings settings
 	
-	ComposeStopRemoveVolumes() {
+	ComposeDownRemoveVolumes() {
 		group = 'docker'
 		description = '''Removes volumes of docker-compose project and 
-						stops associated containers if necessary'''
+						stops/removes associated containers if necessary'''
 	}
 	
 	@TaskAction
-	void removeVolumes() {
+	void downRemoveVolumes() {
 		settings.serviceInfoCache.clear()
 		String[] args = ['down', '-v']
 		def composeLog = null

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeStopRemoveVolumes.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeStopRemoveVolumes.groovy
@@ -1,0 +1,29 @@
+package com.avast.gradle.dockercompose.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction
+
+import com.avast.gradle.dockercompose.ComposeSettings
+
+public class ComposeStopRemoveVolumes extends DefaultTask {
+	ComposeSettings settings
+	
+	ComposeStopRemoveVolumes() {
+		group = 'docker'
+		description = '''Removes volumes of docker-compose project and 
+						stops associated containers if necessary'''
+	}
+	
+	@TaskAction
+	void removeVolumes() {
+		settings.serviceInfoCache.clear()
+		String[] args = ['down', '-v']
+		def composeLog = null
+		if(settings.composeLogToFile) {
+		  logger.debug "Logging docker-compose removeVolumes to : ${settings.composeLogToFile}"
+		  settings.composeLogToFile.parentFile.mkdirs()
+		  composeLog = new FileOutputStream(settings.composeLogToFile, true)
+		}
+		settings.composeExecutor.executeWithCustomOutputWithExitValue(composeLog, args)
+	}
+}


### PR DESCRIPTION
I have found this to a be a useful tool if you want to avoid a testing situation where you need a persistent volume as part of your gradle configuration but once in a while would like to remove the data associated with the container. This is useful particularly when it comes to testing databases.